### PR TITLE
Add optional parameter "newline" to POFile.save()

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ polib is pretty stable now and is used by many
 `opensource projects <http://polib.readthedocs.org/en/latest/projects.html>`_.
 
 The project code and bugtracker is hosted on 
-`Bitbucket <http://bitbucket.org/izi/polib/>`_. 
+`GitHub <https://github.com/izimobil/polib>`_. 
 
 polib is generously documented, you can `browse the documentation online 
 <http://polib.readthedocs.org/>`_, a good start is to read 

--- a/polib.py
+++ b/polib.py
@@ -27,7 +27,7 @@ except ImportError:
     # we use codecs instead
     class io(object):
         @staticmethod
-        def open(fpath, mode='r', encoding=None):
+        def open(fpath, mode='r', encoding=None, newline=None):
             return codecs.open(fpath, mode, encoding)
 
 
@@ -421,7 +421,7 @@ class _BaseFile(list):
             e.flags.append('fuzzy')
         return e
 
-    def save(self, fpath=None, repr_method='__unicode__'):
+    def save(self, fpath=None, repr_method='__unicode__', newline=None):
         """
         Saves the po file to ``fpath``.
         If it is an existing file and no ``fpath`` is provided, then the
@@ -434,6 +434,10 @@ class _BaseFile(list):
 
         ``repr_method``
             string, the method to use for output.
+
+        ``newline``
+            string, controls how universal newlines works.
+            get ignored with python < 2.6
         """
         if self.fpath is None and fpath is None:
             raise IOError('You must provide a file path to save() method')
@@ -443,7 +447,7 @@ class _BaseFile(list):
         if repr_method == 'to_binary':
             fhandle = open(fpath, 'wb')
         else:
-            fhandle = io.open(fpath, 'w', encoding=self.encoding)
+            fhandle = io.open(fpath, 'w', encoding=self.encoding, newline=newline)
             if not isinstance(contents, text_type):
                 contents = contents.decode(self.encoding)
         fhandle.write(contents)


### PR DESCRIPTION
To save a PO file on Windows with Unix line ending, I added the optional parameter `newline` to `POFile.save()`:

```
po = polib.pofile(itemname)
po.merge(refpot)
po.save(newline='\n')
```

Get ignored with python < 2.6