### PR TITLE
Replace dead Bitbucket URLs to current Github repo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ polib is pretty stable now and is used by many
 `opensource projects <http://polib.readthedocs.org/en/latest/projects.html>`_.
 
 The project code and bugtracker is hosted on 
-`Bitbucket <http://bitbucket.org/izi/polib/>`_. 
+`Github <https://github.com/izimobil/polib/>`_.
 
 polib is generously documented, you can `browse the documentation online 
 <http://polib.readthedocs.org/>`_, a good start is to read 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -5,20 +5,20 @@ Contributing to polib
 
 You are very welcome to contribute to the project!
 The bugtracker, wiki and mercurial repository can be found at the 
-`project's page <http://bitbucket.org/izi/polib/>`_.
+`project's page <https://github.com/izimobil/polib/>`_.
 
 New releases are also published at the 
-`cheeseshop <http://cheeseshop.python.org/pypi/polib/>`_.
+`"cheeseshop" (PyPI) <https://pypi.org/project/polib/>`_.
 
 How to contribute
 ~~~~~~~~~~~~~~~~~
 
 There are various possibilities to get involved, for example you can:
 
-* `Report bugs <http://www.bitbucket.org/izi/polib/issues/new/>`_
+* `Report bugs <https://github.com/izimobil/polib/issues/new/>`_
   preferably with patches if you can;
-* Enhance this `documentation <http://www.bitbucket.org/izi/polib/src/tip/docs/>`_
-* `Fork the code <http://www.bitbucket.org/izi/polib/>`_, implement new
+* Enhance this `documentation <https://github.com/izimobil/polib/tree/master/docs/>`_
+* `Fork the code <https://github.com/izimobil/polib/>`_, implement new
   features, test and send a pull request
 
 Running the test suite

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -62,20 +62,20 @@ From a command line in that directory, type::
     privileges (e.g., ``sudo python setup.py install``).
 
 
-Manual installation from a Mercurial checkout
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Manual installation from a Git checkout
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you'd like to try out the latest in-development code, you can obtain it
 from the polib repository, which is hosted at
-`Bitbucket <http://bitbucket.org/>`_ and uses `Mercurial
-<http://www.selenic.com/mercurial/wiki/>`_ for version control.
+`Github <https://github.com/>`_ and uses `Git
+<https://git-scm.com/>`_ for version control.
 
-To obtain the latest code and documentation, you'll need to have Mercurial
+To obtain the latest code and documentation, you'll need to have Git
 installed, at which point you can type::
 
-    hg clone http://bitbucket.org/izi/polib/
+    git clone https://github.com/izimobil/polib/
 
-This will create a copy of the polib Mercurial repository on your computer;
+This will create a copy of the polib Git repository on your computer;
 you can then add the ``polib.py`` file to your Python import path, or use the
 ``setup.py`` script to install as a package.
 

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ if __name__ == '__main__':
         author_email=maintainer_email,
         maintainer=maintainer,
         maintainer_email=maintainer_email,
-        url='http://bitbucket.org/izi/polib/',
+        url='https://github.com/izimobil/polib/',
         download_url='https://pypi.python.org/packages/source/p/polib/polib-%s.tar.gz' % polib.__version__,
         license='MIT',
         platforms=['posix'],


### PR DESCRIPTION
As Bitbucket no longer supports Mercurial repositories, the former host is dead. As Github seems to be the official repository now, I've updated the README. This helps clearing confusions such as raised in https://stackoverflow.com/a/9998895/624066 (see the comments).