### PR TITLE
s/msgtxt/msgstr/ in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ Basic example
     pofile = polib.pofile('/path/to/pofile.po')
 
     for entry in pofile:
-        print(entry.msgid, entry.msgtxt)
+        print(entry.msgid, entry.msgstr)
 
 
 .. |build-status-image| image:: https://secure.travis-ci.org/izimobil/polib.svg?branch=master


### PR DESCRIPTION
Using `msgtxt` here fails for me, but `msgstr` works. Further, I don't see any reference to `msgtxt` in the `gettext` documentation

Please let me know if I've misunderstood

Thanks!