### PR TITLE
Reimplement `POEntry.__eq__` method, based on `__cmp__`

### DIFF
--- a/polib.py
+++ b/polib.py
@@ -1117,10 +1117,42 @@ class POEntry(_BaseEntry):
         return self.__cmp__(other) <= 0
 
     def __eq__(self, other):
-        return self.__cmp__(other) == 0
+        """
+        Called by comparison operations if rich comparison is not defined.
+        """
+        # First: Obsolete test
+        if self.obsolete != other.obsolete:
+            return False
+        # Work on a copy to protect original
+        occ1 = sorted(self.occurrences[:])
+        occ2 = sorted(other.occurrences[:])
+        if occ1 != occ2:
+            return False
+        # Compare context
+        msgctxt = self.msgctxt or '0'
+        othermsgctxt = other.msgctxt or '0'
+        if msgctxt != othermsgctxt:
+            return False
+        # Compare msgid_plural
+        msgid_plural = self.msgid_plural or '0'
+        othermsgid_plural = other.msgid_plural or '0'
+        if msgid_plural != othermsgid_plural:
+            return False
+        # Compare msgstr_plural
+        msgstr_plural = self.msgstr_plural or '0'
+        othermsgstr_plural = other.msgstr_plural or '0'
+        if msgstr_plural != othermsgstr_plural:
+            return False
+        # Compare msgid
+        if self.msgid != other.msgid:
+            return False
+        # Compare msgstr
+        if self.msgstr != other.msgstr:
+            return False
+        return True
 
     def __ne__(self, other):
-        return self.__cmp__(other) != 0
+        return not self.__eq__(other)
 
     def translated(self):
         """


### PR DESCRIPTION
Hello,

I've just come across a problem while trying to extract messages from a Pyramid web app using Mako (1.1.5) templates. As per the Pyramid tutorial, I use Lingua (4.1.4) to extract messages. The error message was:

```
  File "/my-project/venv/bin/pot-create", line 8, in <module>
    sys.exit(main())
  File "/my-project/venv/lib/python3.8/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/my-project/venv/lib/python3.8/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/my-project/venv/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/my-project/venv/lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/my-project/venv/lib/python3.8/site-packages/lingua/extract.py", line 453, in main
    save_catalog(catalog, output)
  File "/my-project/venv/lib/python3.8/site-packages/lingua/extract.py", line 244, in save_catalog
    if old_catalog is not None and identical(catalog, old_catalog):
  File "/my-project/venv/lib/python3.8/site-packages/lingua/extract.py", line 234, in identical
    return a == b
  File "/my-project/venv/lib/python3.8/site-packages/lingua/extract.py", line 67, in __eq__
    r = super(POEntry, self).__eq__(other)
  File "/my-project/venv/lib/python3.8/site-packages/polib.py", line 1120, in __eq__
    return self.__cmp__(other) == 0
  File "/my-project/venv/lib/python3.8/site-packages/polib.py", line 1091, in __cmp__
    if msgstr_plural > othermsgstr_plural:
TypeError: '>' not supported between instances of 'dict' and 'dict'
```

Basically, `pot-create` tries to determine if the catalog needs to be updated, by comparing all entries between the existing catalog and the new one. Now, in `polib`, testing if two entries are equal is ultimately done via the `__cmp__` method, which uses `<` and `>` operators for comparison.

The problem arises as the `msgstr_plural` fields returned by the Lingua extractor can be dicts, and so the `<`and `>` operators no longer apply. Comparing dict equality needs to be done diferently. In this version, I've reimplemented the `__eq__` method so that it only uses `!=`operators.

Polib tests all succeed, to the change doesn't seem to break anything. The only thing that bothers me is code redundancy...

Laurent.