### PR TITLE
Simplify major Python version check

### DIFF
--- a/polib.py
+++ b/polib.py
@@ -34,7 +34,7 @@ default_encoding = 'utf-8'
 # python 2/3 compatibility helpers {{{
 
 
-if sys.version_info[0] < 3:
+if sys.version_info < (3,):
     PY3 = False
     text_type = unicode
 

--- a/polib.py
+++ b/polib.py
@@ -34,7 +34,7 @@ default_encoding = 'utf-8'
 # python 2/3 compatibility helpers {{{
 
 
-if sys.version_info[:2] < (3, 0):
+if sys.version_info[0] < 3:
     PY3 = False
     text_type = unicode
 


### PR DESCRIPTION
Slicing in Python makes a copy.

<details>
  <summary>Performance tests</summary>

```python
$ cat time_test.py
import sys

if sys.argv[1] == "new":
    for i in range(int(sys.argv[2])):
        sys.version_info < (3,)
else:
    for i in range(int(sys.argv[2])):
        sys.version_info[:2] < (3, 0)
$ time python3 time_test.py old 5000000

real	0m0,677s
user	0m0,665s
sys	0m0,012s
$ time python3 time_test.py new 5000000

real	0m0,371s
user	0m0,370s
sys	0m0,001s
$
$ cat timeit_test.py 
import sys
import timeit

if sys.argv[1] == "new":
    def func():
        return sys.version_info < (3,)
else:
    def func():
        return sys.version_info[:2] < (3, 0)

print(timeit.timeit(func, number=int(sys.argv[2])))
$ python3 timeit_test.py old 5000000
0.765341719999924
$ python3 timeit_test.py new 5000000
0.4855887369994889
```

</details>