### PR TITLE
add python 3.10

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py36, py37, py38, py39, pypy, pypy3, lint
+envlist = py27, py36, py37, py38, py39, py310, pypy, pypy3, lint
 
 [testenv]
 commands = coverage run tests/tests.py
@@ -9,6 +9,7 @@ basepython=
     py37: python3.7
     py38: python3.8
     py39: python3.9
+    py310: python3.10
     pypy: pypy
     pypy3: pypy3
     lint: python3.9


### PR DESCRIPTION
I only added the new version of python, I didn't change the target of lint to use python3.10 instead of python3.9 as I'm not sure if it is intended.

Tested locally on my archlinux