### PR TITLE
Ensure empty previous values for msgid and msgstr are properly saved.

### DIFF
--- a/polib.py
+++ b/polib.py
@@ -1053,7 +1053,7 @@ class POEntry(_BaseEntry):
             prefix = "#| "
         for f in fields:
             val = getattr(self, f)
-            if val:
+            if val is not None:
                 ret += self._str_field(f, prefix, "", val, wrapwidth)
 
         ret.append(_BaseEntry.__unicode__(self, wrapwidth))

--- a/tests/test_previous_msgid.po
+++ b/tests/test_previous_msgid.po
@@ -18,3 +18,10 @@ msgstr ""
 #| msgid "Partition table entries are not in disk order2\n"
 msgid "The new msgid2"
 msgstr ""
+
+
+#| msgctxt "Some other message context"
+#| msgid ""
+msgctxt "The new msgctxt3"
+msgid "The new msgid3"
+msgstr ""

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -149,6 +149,23 @@ msgstr "bar"
             expected
         )
 
+    def test_previous_msgid_3(self):
+        """
+        Test saving empty previous msgid.
+        """
+        po = polib.pofile('tests/test_previous_msgid.po')
+        fd, tmpfile = tempfile.mkstemp()
+        os.close(fd)
+        po.save(tmpfile)
+        po = polib.pofile(tmpfile)
+        os.remove(tmpfile)
+
+        expected = ""
+        self.assertEqual(
+            po[2].previous_msgid,
+            expected
+        )
+
     def test_previous_msgctxt_1(self):
         """
         Test previous msgctxt multiline.


### PR DESCRIPTION
This patch prevents polib from creating illegal pofiles (that have `#| msgctxt` but not `#| msgid`).

Here is a simple way to witness the behaviour:

### before.po
```
msgid ""
msgstr ""

#, fuzzy
#| msgctxt "oldcontext"
#| msgid ""
msgctxt "newcontext"
msgid ""
msgstr "After"
```

### test.py
```
import polib
polib.pofile('before.po').save('after.po')
```

### Result

By running `test.py` you can observe that the `#| msgid ""` line has disappeared. This makes the `.po` file invalid, and tools such as _e.g._ `msgmerge` will no longer be able to open it. For instance:

```
# cp after.po after.pot
# msgmerge after.po after.pot
after.po:7:8: syntax error
msgmerge: found 1 fatal error
#
```