### PR TITLE
Add path to error message processing parser symbols

### DIFF
--- a/polib.py
+++ b/polib.py
@@ -1505,6 +1505,8 @@ class _POFileParser(object):
                 self.current_state = state
         except Exception:
             fpath = '%s ' % self.instance.fpath if self.instance.fpath else ''
+            if hasattr(self.fhandle, 'close'):
+                self.fhandle.close()
             raise IOError('Syntax error in po file %s(line %s)' %
                           (fpath, self.current_line))
 

--- a/polib.py
+++ b/polib.py
@@ -1504,8 +1504,9 @@ class _POFileParser(object):
             if action():
                 self.current_state = state
         except Exception:
-            raise IOError('Syntax error in po file (line %s)' %
-                          self.current_line)
+            fpath = '%s ' % self.instance.fpath if self.instance.fpath else ''
+            raise IOError('Syntax error in po file %s(line %s)' %
+                          (fpath, self.current_line))
 
     # state handlers
 

--- a/tests/test_syntax_error1.po
+++ b/tests/test_syntax_error1.po
@@ -1,0 +1,5 @@
+#
+msgid ""
+msgstr ""
+
+msgstr ""

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -237,6 +237,18 @@ msgstr ""
             msg = 'Syntax error in po file (line 4): unescaped double quote found'
             self.assertEqual(str(exc), msg)
 
+    def test_syntax_error1(self):
+        """
+        Test that syntax error is raised while processing a symbol parsing.
+        """
+        try:
+            polib.pofile('tests/test_syntax_error1.po')
+            self.fail("Syntax error not detected")
+        except IOError:
+            exc = sys.exc_info()[1]
+            msg = "Syntax error in po file tests/test_syntax_error1.po (line 5)"
+            self.assertEqual(str(exc), msg)
+
     def test_detect_encoding1(self):
         """
         Test that given encoding is returned when file has no encoding defined.


### PR DESCRIPTION
`IOError`s raised while processing symbols during the parsing does not contain information about the path, but all other `IOError`s raised by the parser contain them.