### PR TITLE
Fix relative ordering of comments and translator comments

### DIFF
--- a/polib.py
+++ b/polib.py
@@ -1000,7 +1000,7 @@ class POEntry(_BaseEntry):
         if self.obsolete:
             comments = [('tcomment', '# ')]
         else:
-            comments = [('comment', '#. '), ('tcomment', '# ')]
+            comments = [('tcomment', '# '), ('comment', '#. ')]
         for c in comments:
             val = getattr(self, c[0])
             if val:

--- a/tests/test_comment_ordering.po
+++ b/tests/test_comment_ordering.po
@@ -1,0 +1,8 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+
+# First comment line
+#. Second comment line
+msgid "foo"
+msgstr "oof"

--- a/tests/test_iso-8859-15.po
+++ b/tests/test_iso-8859-15.po
@@ -10,10 +10,10 @@ msgstr ""
 "Content-Type: text/plain; charset=ISO_8859-15\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. Added for wrapping test, this is a long extracted comment that should be
-#. wrapped by polib, blah, blah, foobar
 # Added for wrapping test, this is a long translated comment that should be
 # wrapped by polib, blah, blah, foobar
+#. Added for wrapping test, this is a long extracted comment that should be
+#. wrapped by polib, blah, blah, foobar
 #: /foo/bar/baz/spam.py:710
 #: /foo/bar/baz/spam-ham-foo-bar-baz-spam-something-bar.py
 msgid "Test wrapping"
@@ -38,7 +38,7 @@ msgstr ""
 msgid "1 line --%d%%--"
 msgstr "1 ligne --%d%%--"
 
-#. ctrl_x_mode == 0, ^P/^N compl.
 # DB - todo : Faut-il une majuscule à "mode" ?
+#. ctrl_x_mode == 0, ^P/^N compl.
 msgid " ^X mode (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
 msgstr " mode ^X (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -602,6 +602,22 @@ msgstr "oof"
 '''
         self.assertEqual(str(pofile), expected)
 
+    def test_comment_ordering(self):
+        """
+        Test that "# " comments appear before "#. " comments when writing.
+        """
+        pofile  = polib.pofile('tests/test_comment_ordering.po')
+        expected = r'''#
+msgid ""
+msgstr "Content-Type: text/plain; charset=UTF-8\n"
+
+# First comment line
+#. Second comment line
+msgid "foo"
+msgstr "oof"
+'''
+        self.assertEqual(str(pofile), expected)
+
 class TestPoFile(unittest.TestCase):
     """
     Tests for PoFile class.


### PR DESCRIPTION
The PO file format documentation indicates that "# " comments should appear before "#." comments (https://www.gnu.org/software/gettext/manual/html_node/PO-Files.html). Also the gettext source code calls message_print_comment() before message_print_comment_dot() when writing a PO file.