### PR TITLE
Implement setter for the `fuzzy` property

### DIFF
--- a/polib.py
+++ b/polib.py
@@ -1188,6 +1188,13 @@ class POEntry(_BaseEntry):
     def fuzzy(self):
         return 'fuzzy' in self.flags
 
+    @fuzzy.setter
+    def fuzzy(self, value):
+        if value and not self.fuzzy:
+            self.flags.insert(0, 'fuzzy')
+        elif not value and self.fuzzy:
+            self.flags.remove('fuzzy')
+
     def __hash__(self):
         return hash((self.msgid, self.msgstr))
 # }}}

--- a/tests/test_set_fuzzy.po
+++ b/tests/test_set_fuzzy.po
@@ -1,0 +1,11 @@
+# test file for setting fuzzy messages
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+
+msgid "a"
+msgstr "a"
+
+#, fuzzy
+msgid "Line"
+msgstr "Ligne"

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -759,6 +759,13 @@ class TestPoFile(unittest.TestCase):
         pofile = polib.pofile('tests/test_obsolete_is_not_fuzzy.po')
         self.assertEqual(len(pofile.fuzzy_entries()), 1)
 
+    def test_set_fuzzy(self):
+        pofile = polib.pofile('tests/test_set_fuzzy.po')
+        pofile[0].fuzzy = True
+        pofile[1].fuzzy = False
+        self.assertTrue(pofile[0].fuzzy)
+        self.assertFalse(pofile[1].fuzzy)
+
 class TestMoFile(unittest.TestCase):
     """
     Tests for MoFile class.


### PR DESCRIPTION
This allows us to do:

```
message = pofile[0]
message.fuzzy = True
```

instead of:

```
message = pofile[0]
if 'fuzzy' not in message.flags:
    message.flags.append("fuzzy")
```