### PR TITLE
tests: force 'msgfmt' into machine's byte order

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -643,7 +643,7 @@ class TestPoFile(unittest.TestCase):
             os.close(fd)
             po = polib.pofile(reffile, autodetect_encoding=False, encoding=encoding)
             po.save_as_mofile(tmpfile1)
-            subprocess.call([msgfmt, '--no-hash', '-o', tmpfile2, reffile])
+            subprocess.call([msgfmt, '--no-hash', '--endianness=%s' % sys.byteorder, '-o', tmpfile2, reffile])
             try:
                 f = open(tmpfile1, 'rb')
                 s1 = f.read()


### PR DESCRIPTION
The change fixes test failures on big-endian machines.

When investigating https://bugs.gentoo.org/641464 I found out msgfmt generates little-endian .mo files even on most of big-endian machines.

polib generates .mo files in native endianness. It should be fine as .mo readers should expect any byte order.

Bug: https://bugs.gentoo.org/641464

Originally posted as https://bitbucket.org/izi/polib/pull-requests/24/