### PR TITLE
customizable entries

### DIFF
--- a/polib.py
+++ b/polib.py
@@ -1006,6 +1006,23 @@ class POEntry(_BaseEntry):
         """
         ret = []
         # comments first, if any (with text wrapping as xgettext does)
+        self._unicode_comments(ret, wrapwidth=wrapwidth)
+
+        # occurrences (with text wrapping as xgettext does)
+        self._unicode_occurrences(ret, wrapwidth=wrapwidth)
+
+        # flags (TODO: wrapping ?)
+        self._unicode_flags(ret, wrapwidth=wrapwidth)
+
+        # previous context and previous msgid/msgid_plural
+        self._unicode_previous(ret, wrapwidth=wrapwidth)
+
+        ret.append(_BaseEntry.__unicode__(self, wrapwidth))
+        ret = u('\n').join(ret)
+        return ret
+
+    def _unicode_comments(self, ret, **kwargs):
+        wrapwidth = kwargs.get('wrapwidth')
         if self.obsolete:
             comments = [('tcomment', '# ')]
         else:
@@ -1025,7 +1042,8 @@ class POEntry(_BaseEntry):
                     else:
                         ret.append('%s%s' % (c[1], comment))
 
-        # occurrences (with text wrapping as xgettext does)
+    def _unicode_occurrences(self, ret, **kwargs):
+        wrapwidth = kwargs.get('wrapwidth')
         if not self.obsolete and self.occurrences:
             filelist = []
             for fpath, lineno in self.occurrences:
@@ -1049,11 +1067,12 @@ class POEntry(_BaseEntry):
             else:
                 ret.append('#: ' + filestr)
 
-        # flags (TODO: wrapping ?)
+    def _unicode_flags(self, ret, **kwargs):
         if self.flags:
             ret.append('#, %s' % ', '.join(self.flags))
 
-        # previous context and previous msgid/msgid_plural
+    def _unicode_previous(self, ret, **kwargs):
+        wrapwidth = kwargs.get('wrapwidth')
         fields = ['previous_msgctxt', 'previous_msgid',
                   'previous_msgid_plural']
         if self.obsolete:
@@ -1064,10 +1083,6 @@ class POEntry(_BaseEntry):
             val = getattr(self, f)
             if val is not None:
                 ret += self._str_field(f, prefix, "", val, wrapwidth)
-
-        ret.append(_BaseEntry.__unicode__(self, wrapwidth))
-        ret = u('\n').join(ret)
-        return ret
 
     def __cmp__(self, other):
         """

--- a/polib.py
+++ b/polib.py
@@ -872,12 +872,34 @@ class _BaseEntry(object):
             delflag = ''
         ret = []
         # write the msgctxt if any
+        self._unicode_msgctxt(ret, wrapwidth=wrapwidth, delflag=delflag)
+        # write the msgid
+        self._unicode_msgid(ret, wrapwidth=wrapwidth, delflag=delflag)
+        # write the msgid_plural if any
+        self._unicode_msgid_plural(ret, wrapwidth=wrapwidth, delflag=delflag)
+
+        ret.append('')
+        ret = u('\n').join(ret)
+        return ret
+
+    def _unicode_msgctxt(self, ret, **kwargs):
+        wrapwidth = kwargs.get("wrapwidth")
+        delflag = kwargs.get("delflag")
+
         if self.msgctxt is not None:
             ret += self._str_field("msgctxt", delflag, "", self.msgctxt,
                                    wrapwidth)
-        # write the msgid
+
+    def _unicode_msgid(self, ret, **kwargs):
+        wrapwidth = kwargs .get("wrapwidth")
+        delflag = kwargs.get("delflag")
+
         ret += self._str_field("msgid", delflag, "", self.msgid, wrapwidth)
-        # write the msgid_plural if any
+
+    def _unicode_msgid_plural(self, ret, **kwargs):
+        wrapwidth = kwargs .get("wrapwidth")
+        delflag = kwargs.get("delflag")
+
         if self.msgid_plural:
             ret += self._str_field("msgid_plural", delflag, "",
                                    self.msgid_plural, wrapwidth)
@@ -895,9 +917,6 @@ class _BaseEntry(object):
             # otherwise write the msgstr
             ret += self._str_field("msgstr", delflag, "", self.msgstr,
                                    wrapwidth)
-        ret.append('')
-        ret = u('\n').join(ret)
-        return ret
 
     if PY3:
         def __str__(self):


### PR DESCRIPTION
Hi there.
For our use case we have specific formatting of the occurrences section in .po files.
So i made POEntry and _BaseEntry easier to customize

With these adjustments i can define a custom `POFile` that creates custom `POEntry` elements.
(I am no python expert. Not sure if I could write this in one line)

```py
class CustomPOFile(polib.POFile):

    def append(self, entry: polib.POEntry) -> None:
        custom = CustomPOEntry(wrapwidth=self.wrapwidth)

        custom.msgid = entry.msgid
        custom.msgstr = entry.msgstr
        custom.msgid_plural = entry.msgid_plural
        custom.msgstr_plural = entry.msgstr_plural
        custom.msgctxt = entry.msgctxt
        custom.obsolete = entry.obsolete
        custom.encoding = entry.encoding
        custom.comment = entry.comment
        custom.tcomment = entry.tcomment
        custom.occurrences = entry.occurrences
        custom.flags = entry.flags
        custom.previous_msgctxt = entry.previous_msgctxt
        custom.previous_msgid = entry.previous_msgid
        custom.previous_msgid_plural = entry.previous_msgid_plural
        custom.linenum = entry.linenum

        return super().append(custom)
```

And in my custom POEntry i can overwrite methods with my custom implementation:

```py
class CustomPOEntry(polib.POEntry):

    def _unicode_occurrences(self, ret, **kwargs):
        # custom stuff
        # ret += [...]
        pass
```

Let me know if you would do something else. (also naming)
As I said: not a python expert.
