### PR TITLE
Update api.rst to document public members of _BaseFile

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -60,3 +60,7 @@ The ``MOEntry`` class
 .. autoclass:: polib.MOEntry
     :members:
 
+
+The ``BaseFile`` class (parent class of both POEntry and MOEntry)
+-----------------------------------------------------------------
+.. autoclass:: polib._BaseFile

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -61,6 +61,8 @@ The ``MOEntry`` class
     :members:
 
 
-The ``BaseFile`` class (parent class of both POEntry and MOEntry)
------------------------------------------------------------------
+The ``_BaseFile`` class
+-----------------------
 .. autoclass:: polib._BaseFile
+    :members:
+


### PR DESCRIPTION
Although _BaseFile shouldn't be instanciated, it contains several members which should be document in the API reference.
