### PR TITLE
Base percent_translated() on words number inside the messages

### DIFF
--- a/polib.py
+++ b/polib.py
@@ -964,8 +964,6 @@ class _BaseEntry(object):
         return self.msgid
 
     def msgid_words(self) -> int:
-        if self.msgid_plural:
-            return len(self.msgid_plural.split())
         return len(self.msgid.split())
 # }}}
 # class POEntry {{{

--- a/polib.py
+++ b/polib.py
@@ -750,10 +750,10 @@ class POFile(_BaseFile):
                 entry.obsolete = True
 
     def total_words(self) -> int:
-        return sum(e.words() for e in self if not e.obsolete)
+        return sum(e.msgid_words() for e in self if not e.obsolete)
 
     def translated_words(self) -> int:
-        return sum(e.words() for e in self if e.translated())
+        return sum(e.msgid_words() for e in self if e.translated())
 # }}}
 # class MOFile {{{
 
@@ -963,7 +963,7 @@ class _BaseEntry(object):
             return '%s%s%s' % (self.msgctxt, "\x04", self.msgid)
         return self.msgid
 
-    def words(self) -> int:
+    def msgid_words(self) -> int:
         if self.msgid_plural:
             return len(self.msgid_plural.split())
         return len(self.msgid.split())

--- a/polib.py
+++ b/polib.py
@@ -683,12 +683,12 @@ class POFile(_BaseFile):
     def percent_translated(self):
         """
         Convenience method that returns the percentage of translated
-        messages.
+        words.
         """
-        total = len([e for e in self if not e.obsolete])
+        total = self.total_words()
         if total == 0:
             return 100
-        translated = len(self.translated_entries())
+        translated = self.translated_words()
         return int(translated * 100 / float(total))
 
     def translated_entries(self):
@@ -748,6 +748,12 @@ class POFile(_BaseFile):
         for entry in self:
             if entry.msgid_with_context not in refpot_msgids:
                 entry.obsolete = True
+
+    def total_words(self) -> int:
+        return sum(e.words() for e in self if not e.obsolete)
+
+    def translated_words(self) -> int:
+        return sum(e.words() for e in self if e.translated())
 # }}}
 # class MOFile {{{
 
@@ -956,6 +962,11 @@ class _BaseEntry(object):
         if self.msgctxt:
             return '%s%s%s' % (self.msgctxt, "\x04", self.msgid)
         return self.msgid
+
+    def words(self) -> int:
+        if self.msgid_plural:
+            return len(self.msgid_plural.split())
+        return len(self.msgid.split())
 # }}}
 # class POEntry {{{
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -705,6 +705,10 @@ class TestPoFile(unittest.TestCase):
         po = polib.pofile('tests/test_pofile_helpers.po')
         self.assertEqual(len(po.translated_entries()), 7)
 
+    def test_translated_words(self):
+        po = polib.pofile('tests/test_pofile_helpers.po')
+        self.assertEqual(po.translated_words(), 40)
+
     def test_untranslated_entries(self):
         po = polib.pofile('tests/test_pofile_helpers.po')
         self.assertEqual(len(po.untranslated_entries()), 4)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -417,7 +417,7 @@ msgstr ""
 
     def test_entry_words(self):
         po = polib.pofile('tests/test_utf8.po')
-        self.assertEqual(po[0].words(), 2)
+        self.assertEqual(po[0].msgid_words(), 2)
 
 
 class TestBaseFile(unittest.TestCase):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -697,7 +697,7 @@ class TestPoFile(unittest.TestCase):
 
     def test_percent_translated(self):
         po = polib.pofile('tests/test_pofile_helpers.po')
-        self.assertEqual(po.percent_translated(), 53)
+        self.assertEqual(po.percent_translated(), 54)
         po = polib.POFile()
         self.assertEqual(po.percent_translated(), 100)
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -415,6 +415,10 @@ msgstr ""
         self.assertFalse(polib._is_file('This is not a file !!!!'))
         self.assertFalse(polib._is_file(True))
 
+    def test_entry_words(self):
+        po = polib.pofile('tests/test_utf8.po')
+        self.assertEqual(po[0].words(), 2)
+
 
 class TestBaseFile(unittest.TestCase):
     """

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -709,6 +709,10 @@ class TestPoFile(unittest.TestCase):
         po = polib.pofile('tests/test_pofile_helpers.po')
         self.assertEqual(len(po.translated_entries()), 7)
 
+    def test_total_words(self):
+        po = polib.pofile('tests/test_pofile_helpers.po')
+        self.assertEqual(po.total_words(), 74)
+
     def test_translated_words(self):
         po = polib.pofile('tests/test_pofile_helpers.po')
         self.assertEqual(po.translated_words(), 40)


### PR DESCRIPTION
Add `total_words()` and `translated_words()` to `POFile` and `_BaseEntry.words()`.

Please note it's not backwards compatible for code that relies on `percent_translated()`.

This way the completion calculation expresses translation effort more precisely.

The performance penalty of this feature is 8%, according to my checks.

* master: 0.009366210000007414 second
* words branch: 0.010117883330094628 second

Tested on https://github.com/python/python-docs-pl/blob/3.13/library/functions.po.