### PR TITLE
Don't crash if entry have only msgid symbol

### DIFF
--- a/polib.py
+++ b/polib.py
@@ -1320,9 +1320,9 @@ class _POFileParser(object):
         self.add('pm', all,                                              'pm')
         self.add('pp', all,                                              'pp')
         self.add('ct', ['st', 'he', 'gc', 'oc', 'fl', 'tc', 'pc', 'pm',
-                        'pp', 'ms', 'mx'],                               'ct')
+                        'pp', 'ms', 'mx', 'mi'],                         'ct')
         self.add('mi', ['st', 'he', 'gc', 'oc', 'fl', 'ct', 'tc', 'pc',
-                 'pm', 'pp', 'ms', 'mx'],                                'mi')
+                 'pm', 'pp', 'ms', 'mx', 'mi'],                          'mi')
         self.add('mp', ['tc', 'gc', 'pc', 'pm', 'pp', 'mi'],             'mp')
         self.add('ms', ['mi', 'mp', 'tc'],                               'ms')
         self.add('mx', ['mi', 'mx', 'mp', 'tc'],                         'mx')


### PR DESCRIPTION
[OmegaT](https://omegat.org/) can generate somewhat borked output like this:

```
#
msgid ""

msgid "Languages"
msgstr "Język"
```

This example causes state machine in polib to crash (as that kind of input isn't expected), this PR adds msgid as one of the next possible tokens, making the whole file "parseable"
